### PR TITLE
Add Python 3 and PEP 8 compatibility and fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Migrated from [Google Code Archive](https://code.google.com/archive/p/pygapbide/). Python implementation of [Gap-Bide algorithm](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.140.6278&rep=rep1&type=pdf).
 
-To use the code: 
+To use the code:
 
-```
+```python
 from pygapbide import *
 sdb = [[1, 2, 3, 4],
        [1, 4, 2, 3, 5],

--- a/pygapbide.py
+++ b/pygapbide.py
@@ -51,7 +51,7 @@ class Gapbide:
         '''
         overide this function to output patterns to files.
         '''
-        print pattern, sup, pad
+        print(pattern, sup, pad)
         
     def gen_l1_patterns(self):
         '''
@@ -61,7 +61,7 @@ class Gapbide:
         for sid in range(len(self.sdb)):
             seq = self.sdb[sid]
             for pos in range(len(seq)):
-                if pdb_dict.has_key( seq[pos] ):
+                if seq[pos] in pdb_dict:
                     pdb_dict[seq[pos]].append( (sid, pos, pos) )
                 else:
                     pdb_dict[seq[pos]] = [ (sid, pos, pos) ]
@@ -91,7 +91,7 @@ class Gapbide:
             if new_begin >= len(seq): continue
             if new_end > len(seq): new_end = len(seq)
             for pos in range(new_begin, new_end):
-                if pdb_dict.has_key( seq[pos] ):
+                if seq[pos] in pdb_dict:
                     pdb_dict[seq[pos]].append( (sid, begin, pos) )
                 else:
                     pdb_dict[seq[pos]] = [ (sid, begin, pos) ]
@@ -113,7 +113,7 @@ class Gapbide:
             if new_begin >= len(seq): continue
             if new_end > len(seq): new_end = len(seq)
             for pos in range(new_begin, new_end):
-                if sids.has_key( seq[pos] ):
+                if seq[pos] in sids:
                     sids[ seq[pos] ].append( sid )
                 else:
                     sids[ seq[pos] ] = [sid]
@@ -135,7 +135,7 @@ class Gapbide:
             if new_end < 0: continue
             if new_begin < 0: new_begin = 0
             for pos in range(new_begin, new_end):
-                if sids.has_key( seq[pos] ):
+                if seq[pos] in sids:
                     sids[ seq[pos] ].append( sid )
                 else:
                     sids[ seq[pos] ] = [sid]
@@ -149,5 +149,3 @@ class Gapbide:
             if backward and prune:
                 break
         return (backward, prune)
-
-    

--- a/pygapbide.py
+++ b/pygapbide.py
@@ -51,7 +51,7 @@ class Gapbide:
         '''
         overide this function to output patterns to files.
         '''
-        print(pattern, sup, pad)
+        print(pattern, sup, pdb)
         
     def gen_l1_patterns(self):
         '''

--- a/pygapbide.py
+++ b/pygapbide.py
@@ -1,32 +1,34 @@
 '''
 Python implementation of the Gap-Bide algorithm.
 Based on
-Chun Li,Jianyong Wang. 
+Chun Li,Jianyong Wang.
 Efficiently Mining Closed Subsequences with Gap Constraints.
 Siam SDM 2008.
 
 Copyright (c) 2017 by Chun Li
 
-Permission is hereby granted, free of charge, to any person 
-obtaining a copy of this software and associated documentation 
-files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, 
-publish, distribute, sublicense, and/or sell copies of the Software, 
-and to permit persons to whom the Software is furnished to do so, 
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be 
+The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS 
-BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN 
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
+
+
 class Gapbide:
     def __init__(self, sdb, sup, m, n):
         '''
@@ -41,18 +43,18 @@ class Gapbide:
         self.count_closed = 0
         self.count_non_closed = 0
         self.count_pruned = 0
-    
+
     def run(self):
-        l1_patterns= self.gen_l1_patterns()
-        for pattern,sup,pdb in l1_patterns:
-            self.span( pattern, sup, pdb )
-    
-    def output(self, pattern, sup , pdb):
+        l1_patterns = self.gen_l1_patterns()
+        for pattern, sup, pdb in l1_patterns:
+            self.span(pattern, sup, pdb)
+
+    def output(self, pattern, sup, pdb):
         '''
         overide this function to output patterns to files.
         '''
         print(pattern, sup, pdb)
-        
+
     def gen_l1_patterns(self):
         '''
         generate length-1 patterns
@@ -62,25 +64,25 @@ class Gapbide:
             seq = self.sdb[sid]
             for pos in range(len(seq)):
                 if seq[pos] in pdb_dict:
-                    pdb_dict[seq[pos]].append( (sid, pos, pos) )
+                    pdb_dict[seq[pos]].append((sid, pos, pos))
                 else:
-                    pdb_dict[seq[pos]] = [ (sid, pos, pos) ]
+                    pdb_dict[seq[pos]] = [(sid, pos, pos)]
         patterns = []
         for item, pdb in pdb_dict.items():
             sup = len(set([i[0] for i in pdb]))
             if sup >= self.sup:
-                patterns.append( ([item], sup, pdb) )
+                patterns.append(([item], sup, pdb))
         return patterns
-    
+
     def span(self, pattern, sup, pdb):
-        (backward,prune) = self.backward_check( pattern, sup, pdb)
+        (backward, prune) = self.backward_check(pattern, sup, pdb)
         if prune:
             self.count_pruned += 1
             return
         forward = self.forward_check(pattern, sup, pdb)
-        if not( backward or forward):
+        if not(backward or forward):
             self.count_closed += 1
-            self.output( pattern, sup, pdb )
+            self.output(pattern, sup, pdb)
         else:
             self.count_non_closed += 1
         pdb_dict = dict()
@@ -88,21 +90,23 @@ class Gapbide:
             seq = self.sdb[sid]
             new_begin = end + 1 + self.m
             new_end = end + 2 + self.n
-            if new_begin >= len(seq): continue
-            if new_end > len(seq): new_end = len(seq)
+            if new_begin >= len(seq):
+                continue
+            if new_end > len(seq):
+                new_end = len(seq)
             for pos in range(new_begin, new_end):
                 if seq[pos] in pdb_dict:
-                    pdb_dict[seq[pos]].append( (sid, begin, pos) )
+                    pdb_dict[seq[pos]].append((sid, begin, pos))
                 else:
-                    pdb_dict[seq[pos]] = [ (sid, begin, pos) ]
+                    pdb_dict[seq[pos]] = [(sid, begin, pos)]
         for item, new_pdb in pdb_dict.items():
             sup = len(set([i[0] for i in new_pdb]))
             if sup >= self.sup:
-                #add new pattern
+                # add new pattern
                 new_pattern = pattern[:]
                 new_pattern.append(item)
                 self.span(new_pattern, sup, new_pdb)
-                
+
     def forward_check(self, pattern, sup, pdb):
         sids = {}
         forward = False
@@ -110,14 +114,16 @@ class Gapbide:
             seq = self.sdb[sid]
             new_begin = end + 1 + self.m
             new_end = end + 2 + self.n
-            if new_begin >= len(seq): continue
-            if new_end > len(seq): new_end = len(seq)
+            if new_begin >= len(seq):
+                continue
+            if new_end > len(seq):
+                new_end = len(seq)
             for pos in range(new_begin, new_end):
                 if seq[pos] in sids:
-                    sids[ seq[pos] ].append( sid )
+                    sids[seq[pos]].append(sid)
                 else:
-                    sids[ seq[pos] ] = [sid]
-        for item,sidlist in sids.items():
+                    sids[seq[pos]] = [sid]
+        for item, sidlist in sids.items():
             seq_sup = len(set(sidlist))
             if seq_sup == sup:
                 forward = True
@@ -132,14 +138,16 @@ class Gapbide:
             seq = self.sdb[sid]
             new_begin = begin - self.n - 1
             new_end = begin - self.m
-            if new_end < 0: continue
-            if new_begin < 0: new_begin = 0
+            if new_end < 0:
+                continue
+            if new_begin < 0:
+                new_begin = 0
             for pos in range(new_begin, new_end):
                 if seq[pos] in sids:
-                    sids[ seq[pos] ].append( sid )
+                    sids[seq[pos]].append(sid)
                 else:
-                    sids[ seq[pos] ] = [sid]
-        for item,sidlist in sids.items():
+                    sids[seq[pos]] = [sid]
+        for item, sidlist in sids.items():
             seq_sup = len(set(sidlist))
             uni_sup = len(sidlist)
             if uni_sup == len(pdb):


### PR DESCRIPTION
Thanks for your Gap-BIDE implementation.

I don't know what are your plans regarding Python versions, but as I solely work with Python 3 I made it Python 3 compatible (11c7295), fixed a typo (678a28e) in a variable name and reformatted the code (cb75290) to match [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).

Finally, I enabled (0b01cbe) the syntax highlighting in the readme.